### PR TITLE
phpstan now knows that docblocks are just hints

### DIFF
--- a/phpstan.neon
+++ b/phpstan.neon
@@ -2,8 +2,4 @@ parameters:
   level: 7
   paths:
     - src/
-
-  ignoreErrors:
-    # phpstan trusts phpdoc. this makes sense for applications, not for the public interface of a library
-    # this likely won't be changed: https://github.com/phpstan/phpstan/issues/1926
-    - '#Result of \|\| is always false#'
+  treatPhpDocTypesAsCertain: false


### PR DESCRIPTION
retry once phpstan 0.12.6 has been released