### PR TITLE
Allow PHP8

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -20,10 +20,14 @@ matrix:
     - php: '7.2'
 
     - php: '7.3'
-      env:
-      - PHPSTAN=true
 
     - php: '7.4'
+
+    - php: '8.0'
+      env:
+          - PHPSTAN=true
+
+    - php: '8.1'
 
 install:
 - composer update ${COMPOSER_FLAGS} --prefer-dist --no-interaction

--- a/composer.json
+++ b/composer.json
@@ -14,7 +14,7 @@
         "issues": "https://github.com/liip/serializer-jms-adapter/issues"
     },
     "require": {
-        "php": "^7.2",
+        "php": "^7.2 || ^8.0",
         "ext-json": "*",
         "doctrine/annotations": "^1.6",
         "jms/serializer": "^2.0||^3.0",
@@ -23,10 +23,10 @@
         "psr/log": "^1"
     },
     "require-dev": {
-        "phpstan/phpstan-shim": "^0.11.0",
-        "phpstan/phpstan-phpunit": "^0.11",
+        "phpstan/phpstan": "1.7.9",
+        "phpstan/phpstan-phpunit": "^1.1.1",
         "phpunit/phpunit": "^8.4",
-        "friendsofphp/php-cs-fixer": "v2.14.0"
+        "friendsofphp/php-cs-fixer": "v2.19.3"
     },
     "autoload": {
         "psr-4": {

--- a/composer.json
+++ b/composer.json
@@ -20,7 +20,7 @@
         "jms/serializer": "^2.0||^3.0",
         "liip/serializer": "^1.0 || ^2.0",
         "pnz/json-exception": "^1.0",
-        "psr/log": "^1"
+        "psr/log": "^1 | ^2 | ^3"
     },
     "require-dev": {
         "phpstan/phpstan": "1.7.9",

--- a/phpstan.neon
+++ b/phpstan.neon
@@ -2,4 +2,7 @@ parameters:
     ignoreErrors:
         # phpstan trusts phpdoc. this makes sense for applications, not for the public interface of a library
         # this likely won't be changed: https://github.com/phpstan/phpstan/issues/1926
-        - '#Result of || is always false#'
+        - '#Result of \|\| is always false#'
+        # If a type "mixed" is added via phpdoc, the php-cs-fixer will remove this docblock again because the docblock
+        # is seen as superfluous, so we ignore this error.
+        - '#Method Liip\\Serializer\\Adapter\\JMS\\JMSSerializerAdapter::useLiipSerializer\(\) has parameter \$data with no type specified\.#'

--- a/src/JMSSerializerAdapter.php
+++ b/src/JMSSerializerAdapter.php
@@ -110,6 +110,9 @@ class JMSSerializerAdapter implements SerializerInterface, ArrayTransformerInter
         return $this->originalSerializer->deserialize($data, $type, $format, $context);
     }
 
+    /**
+     * @return array<mixed>
+     */
     public function toArray($data, ?SerializationContext $context = null, ?string $type = null): array
     {
         if ($this->useLiipSerializer($data, $context)) {
@@ -126,6 +129,9 @@ class JMSSerializerAdapter implements SerializerInterface, ArrayTransformerInter
         return $this->originalSerializer->toArray($data, $context, $type);
     }
 
+    /**
+     * @param array<mixed> $data
+     */
     public function fromArray(array $data, string $type, ?DeserializationContext $context = null)
     {
         if ($this->useLiipDeserializer($type, $context)) {

--- a/tests/Fixtures/DummyJmsSerializer.php
+++ b/tests/Fixtures/DummyJmsSerializer.php
@@ -1,0 +1,12 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\Liip\Serializer\Adapter\JMS\Fixtures;
+
+use JMS\Serializer\ArrayTransformerInterface;
+use JMS\Serializer\SerializerInterface;
+
+interface DummyJmsSerializer extends SerializerInterface, ArrayTransformerInterface
+{
+}

--- a/tests/Unit/JMSSerializerAdapterTest.php
+++ b/tests/Unit/JMSSerializerAdapterTest.php
@@ -14,6 +14,7 @@ use Liip\Serializer\SerializerInterface as LiipSerializer;
 use PHPUnit\Framework\MockObject\MockObject;
 use PHPUnit\Framework\TestCase;
 use Psr\Log\NullLogger;
+use Tests\Liip\Serializer\Adapter\JMS\Fixtures\DummyJmsSerializer;
 use Tests\Liip\Serializer\Adapter\JMS\Fixtures\TestModel;
 
 /**
@@ -40,7 +41,7 @@ class JMSSerializerAdapterTest extends TestCase
 
     protected function setUp(): void
     {
-        $this->jms = $this->createMock([SerializerInterface::class, ArrayTransformerInterface::class]);
+        $this->jms = $this->createMock(DummyJmsSerializer::class);
         $this->liip = $this->createMock(LiipSerializer::class);
         $this->model = new TestModel();
     }


### PR DESCRIPTION
With these changes it is now possible to use this adapter with php 8.x. 

I also had to adjust some typings as the phpstan version I updated to complained about some errors.