### PR TITLE
added mixed return type to given methods and set required php version…

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -14,7 +14,7 @@
         "issues": "https://github.com/liip/serializer-jms-adapter/issues"
     },
     "require": {
-        "php": "^7.2 || ^8.0",
+        "php": "^8.0",
         "ext-json": "*",
         "doctrine/annotations": "^1.6",
         "jms/serializer": "^2.0||^3.0",

--- a/src/JMSSerializerAdapter.php
+++ b/src/JMSSerializerAdapter.php
@@ -94,7 +94,7 @@ class JMSSerializerAdapter implements SerializerInterface, ArrayTransformerInter
         return $this->originalSerializer->serialize($data, $format, $context, $type);
     }
 
-    public function deserialize(string $data, string $type, string $format, ?DeserializationContext $context = null)
+    public function deserialize(string $data, string $type, string $format, ?DeserializationContext $context = null): mixed
     {
         if ('json' === $format && $this->useLiipDeserializer($type, $context)) {
             try {
@@ -132,7 +132,7 @@ class JMSSerializerAdapter implements SerializerInterface, ArrayTransformerInter
     /**
      * @param array<mixed> $data
      */
-    public function fromArray(array $data, string $type, ?DeserializationContext $context = null)
+    public function fromArray(array $data, string $type, ?DeserializationContext $context = null): mixed
     {
         if ($this->useLiipDeserializer($type, $context)) {
             try {


### PR DESCRIPTION
… to minimum 8

| Q               | A
| --------------- | ---
| Bug fix?        | no|yes
| New feature?    | no|yes
| BC breaks?      | no|yes
| Deprecations?   | no|yes
| License         | MIT


#### What's in this PR?

added mixed return type to given methods and set required php version to minimum 8


#### Why?

there were deprcation warnings
