### PR TITLE
Apply CS fixes to get rid of PHP 8.4 deprecations

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,11 @@ Changelog
 2.x
 ===
 
+2.2.2 (unreleased)
+-----
+
+* Fix deprecations for PHP 8.4
+
 2.2.1
 -----
 

--- a/composer.json
+++ b/composer.json
@@ -22,7 +22,7 @@
         "psr/log": "^1 | ^2 | ^3"
     },
     "require-dev": {
-        "friendsofphp/php-cs-fixer": "^3.20",
+        "friendsofphp/php-cs-fixer": "^v3.72.0",
         "phpstan/phpstan": "^1.2",
         "phpstan/phpstan-phpunit": "^1.0",
         "phpunit/phpunit": "^9.6",

--- a/composer.json
+++ b/composer.json
@@ -23,10 +23,10 @@
     },
     "require-dev": {
         "friendsofphp/php-cs-fixer": "^v3.72.0",
-        "phpstan/phpstan": "^1.2",
-        "phpstan/phpstan-phpunit": "^1.0",
+        "phpstan/phpstan": "^2.1.8",
+        "phpstan/phpstan-phpunit": "^2.0.1",
         "phpunit/phpunit": "^9.6",
-        "rector/rector": "^0.18.0"
+        "rector/rector": "^2.0.10"
     },
     "autoload": {
         "psr-4": {

--- a/rector.php
+++ b/rector.php
@@ -5,25 +5,22 @@ declare(strict_types=1);
 use Rector\Caching\ValueObject\Storage\FileCacheStorage;
 use Rector\CodeQuality\Rector\Class_\InlineConstructorDefaultToPropertyRector;
 use Rector\Config\RectorConfig;
-use Rector\PHPUnit\Set\PHPUnitLevelSetList;
+use Rector\PHPUnit\Set\PHPUnitSetList;
 use Rector\Set\ValueObject\LevelSetList;
 use Rector\Set\ValueObject\SetList;
 use Rector\TypeDeclaration\Rector\Class_\PropertyTypeFromStrictSetterGetterRector;
 use Rector\TypeDeclaration\Rector\ClassMethod\AddMethodCallBasedStrictParamTypeRector;
 use Rector\TypeDeclaration\Rector\ClassMethod\AddParamTypeFromPropertyTypeRector;
+use Rector\TypeDeclaration\Rector\ClassMethod\BoolReturnTypeFromBooleanStrictReturnsRector;
 use Rector\TypeDeclaration\Rector\ClassMethod\ParamTypeByMethodCallTypeRector;
-use Rector\TypeDeclaration\Rector\ClassMethod\ReturnTypeFromStrictBoolReturnExprRector;
 use Rector\TypeDeclaration\Rector\ClassMethod\ReturnTypeFromStrictConstantReturnRector;
 use Rector\TypeDeclaration\Rector\ClassMethod\ReturnTypeFromStrictNativeCallRector;
 use Rector\TypeDeclaration\Rector\ClassMethod\ReturnTypeFromStrictNewArrayRector;
 use Rector\TypeDeclaration\Rector\ClassMethod\ReturnTypeFromStrictParamRector;
-use Rector\TypeDeclaration\Rector\ClassMethod\ReturnTypeFromStrictScalarReturnExprRector;
 use Rector\TypeDeclaration\Rector\ClassMethod\ReturnTypeFromStrictTypedCallRector;
 use Rector\TypeDeclaration\Rector\ClassMethod\ReturnTypeFromStrictTypedPropertyRector;
-use Rector\TypeDeclaration\Rector\Param\ParamTypeFromStrictTypedPropertyRector;
-use Rector\TypeDeclaration\Rector\Property\TypedPropertyFromStrictConstructorReadonlyClassRector;
+use Rector\TypeDeclaration\Rector\ClassMethod\StringReturnTypeFromStrictScalarReturnsRector;
 use Rector\TypeDeclaration\Rector\Property\TypedPropertyFromStrictConstructorRector;
-use Rector\TypeDeclaration\Rector\Property\TypedPropertyFromStrictGetterMethodReturnTypeRector;
 use Rector\TypeDeclaration\Rector\Property\TypedPropertyFromStrictSetUpRector;
 
 return static function (RectorConfig $rectorConfig): void {
@@ -34,22 +31,18 @@ return static function (RectorConfig $rectorConfig): void {
 
     $rectorConfig->rules([
         InlineConstructorDefaultToPropertyRector::class,
-        ReturnTypeFromStrictBoolReturnExprRector::class,
+        BoolReturnTypeFromBooleanStrictReturnsRector::class,
         ReturnTypeFromStrictConstantReturnRector::class,
         ReturnTypeFromStrictNativeCallRector::class,
         ReturnTypeFromStrictNewArrayRector::class,
         ReturnTypeFromStrictParamRector::class,
-        ReturnTypeFromStrictScalarReturnExprRector::class,
+        StringReturnTypeFromStrictScalarReturnsRector::class,
         ReturnTypeFromStrictTypedCallRector::class,
         ReturnTypeFromStrictTypedPropertyRector::class,
         PropertyTypeFromStrictSetterGetterRector::class,
-        TypedPropertyFromStrictConstructorReadonlyClassRector::class,
         TypedPropertyFromStrictConstructorRector::class,
-        TypedPropertyFromStrictGetterMethodReturnTypeRector::class,
         TypedPropertyFromStrictSetUpRector::class,
-        ParamTypeFromStrictTypedPropertyRector::class,
         AddMethodCallBasedStrictParamTypeRector::class,
-
         ParamTypeByMethodCallTypeRector::class,
         AddParamTypeFromPropertyTypeRector::class,
     ]);
@@ -57,7 +50,7 @@ return static function (RectorConfig $rectorConfig): void {
     $rectorConfig->sets([
         LevelSetList::UP_TO_PHP_80,
         SetList::TYPE_DECLARATION,
-        PHPUnitLevelSetList::UP_TO_PHPUNIT_90,
+        PHPUnitSetList::PHPUNIT_90,
     ]);
 
     // use imports instead of FQN: https://github.com/rectorphp/rector/blob/main/docs/auto_import_names.md#auto-import-names

--- a/src/JMSSerializerAdapter.php
+++ b/src/JMSSerializerAdapter.php
@@ -60,7 +60,6 @@ class JMSSerializerAdapter implements SerializerInterface, ArrayTransformerInter
             $this->enabledClasses = null;
         } else {
             $map = array_combine($enabledClasses, array_fill(0, \count($enabledClasses), true));
-            \assert(\is_array($map));
             $this->enabledClasses = $map;
         }
     }

--- a/src/JMSSerializerAdapter.php
+++ b/src/JMSSerializerAdapter.php
@@ -45,12 +45,12 @@ class JMSSerializerAdapter implements SerializerInterface, ArrayTransformerInter
         private LiipSerializer $liipSerializer,
         object $originalSerializer,
         private LoggerInterface $logger,
-        array $enabledClasses = null
+        ?array $enabledClasses = null,
     ) {
         if (!$originalSerializer instanceof SerializerInterface
             || !$originalSerializer instanceof ArrayTransformerInterface
         ) {
-            throw new \InvalidArgumentException(sprintf(
+            throw new \InvalidArgumentException(\sprintf(
                 'Original serializer must implement both ArrayTransformerInterface and SerializerInterface, but is %s',
                 $originalSerializer::class
             ));
@@ -65,7 +65,7 @@ class JMSSerializerAdapter implements SerializerInterface, ArrayTransformerInter
         }
     }
 
-    public function serialize($data, string $format, SerializationContext $context = null, string $type = null): string
+    public function serialize($data, string $format, ?SerializationContext $context = null, ?string $type = null): string
     {
         if ('json' === $format && $this->useLiipSerializer($data, $context)) {
             try {
@@ -81,7 +81,7 @@ class JMSSerializerAdapter implements SerializerInterface, ArrayTransformerInter
         return $this->originalSerializer->serialize($data, $format, $context, $type);
     }
 
-    public function deserialize(string $data, string $type, string $format, DeserializationContext $context = null): mixed
+    public function deserialize(string $data, string $type, string $format, ?DeserializationContext $context = null): mixed
     {
         if ('json' === $format && $this->useLiipDeserializer($type, $context)) {
             try {
@@ -100,7 +100,7 @@ class JMSSerializerAdapter implements SerializerInterface, ArrayTransformerInter
     /**
      * @return array<mixed>
      */
-    public function toArray($data, SerializationContext $context = null, string $type = null): array
+    public function toArray($data, ?SerializationContext $context = null, ?string $type = null): array
     {
         if ($this->useLiipSerializer($data, $context)) {
             try {
@@ -119,7 +119,7 @@ class JMSSerializerAdapter implements SerializerInterface, ArrayTransformerInter
     /**
      * @param array<mixed> $data
      */
-    public function fromArray(array $data, string $type, DeserializationContext $context = null): mixed
+    public function fromArray(array $data, string $type, ?DeserializationContext $context = null): mixed
     {
         if ($this->useLiipDeserializer($type, $context)) {
             try {
@@ -135,7 +135,7 @@ class JMSSerializerAdapter implements SerializerInterface, ArrayTransformerInter
         return $this->originalSerializer->fromArray($data, $type, $context);
     }
 
-    private function createLiipContext(SerializationContext|null|DeserializationContext $context): ?Context
+    private function createLiipContext(SerializationContext|DeserializationContext|null $context): ?Context
     {
         if (null === $context) {
             return null;
@@ -168,7 +168,7 @@ class JMSSerializerAdapter implements SerializerInterface, ArrayTransformerInter
         }
         if (null !== $context) {
             if (!$context instanceof AdapterSerializationContext) {
-                throw new \InvalidArgumentException(sprintf(
+                throw new \InvalidArgumentException(\sprintf(
                     'Serialization context for %s needs to be an instance of %s, %s given',
                     self::class,
                     AdapterSerializationContext::class,


### PR DESCRIPTION
| Q               | A
| --------------- | ---
| Bug fix?        | kind of
| New feature?    | no
| BC breaks?      | no
| Deprecations?   | no
| Related tickets | none
| Documentation   | -
| License         | MIT


#### What's in this PR?

Applying mainly CS fixes so the code no longer throws deprecation messages in PHP 8.4
I also updated to the latest rector version and removed (or replaced with the new alterntaive) the rules which no longer existed.

#### Why?

Get rid of deprecation notices when using PHP 8.4

#### Checklist

- [x] Updated CHANGELOG.md to describe BC breaks / deprecations | new feature | bugfix
This will also support the latest fixes for PHP 8.4