### PR TITLE
Update composer.json to allow liip/serializer 3.x

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,7 @@ Changelog
 2.x
 ===
 
-2.3.0
+2.2.3
 -----
 
 * Allow `liip/serializer` 3.x to be used 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,11 @@ Changelog
 2.x
 ===
 
+2.3.0
+-----
+
+* Allow `liip/serializer` 3.x to be used 
+
 2.2.2
 -----
 

--- a/composer.json
+++ b/composer.json
@@ -16,8 +16,8 @@
     "require": {
         "php": "^8.0",
         "ext-json": "*",
-        "jms/serializer": "^2.0||^3.0",
-        "liip/serializer": "^1.0 || ^2.0",
+        "jms/serializer": "^2.0 || ^3.0",
+        "liip/serializer": "^1.0 || ^2.0 || ^3.0",
         "pnz/json-exception": "^1.0",
         "psr/log": "^1 | ^2 | ^3"
     },


### PR DESCRIPTION
liip/serializer 3.x does not update its SerializerInterface, or the Serializer/Deserializer in a significant way, so the adapter still works with it, and should be allowed to.

| Q               | A
| --------------- | ---
| Bug fix?        | no
| New feature?    | no
| BC breaks?      | no
| Deprecations?   | no
| Related tickets | 
| Documentation   | Allows the new liip/serializer 3.x to be used with this adapter
| License         | MIT


#### What's in this PR?

This PR allows liip/serializer 3.x to be used with this adapter.


#### Why?

liip/serializer 3.x does not update its SerializerInterface, or the Serializer/Deserializer in a significant way, so the adapter still works with it. The current `composer.json` disallows upgrading to the serializer 3.x, so this PR adds the 3.x top the constraints. I believe this causes no BC break by itself.


#### Checklist

- [x] Updated CHANGELOG.md to describe BC breaks / deprecations | new feature | bugfix
- [x] Documentation pull request created (if not simply a bugfix)

